### PR TITLE
Added support for pycocotools build on windows

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -46,6 +46,7 @@ __version__ = '2.0'
 
 import json
 import time
+import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Polygon
@@ -230,7 +231,7 @@ class COCO:
         elif type(ids) == int:
             return [self.imgs[ids]]
 
-    def showAnns(self, anns, draw_bbox=False):
+    def showAnns(self, anns):
         """
         Display the specified annotations.
         :param anns (array of object): annotations to display
@@ -286,14 +287,6 @@ class COCO:
                             plt.plot(x[sk],y[sk], linewidth=3, color=c)
                     plt.plot(x[v>0], y[v>0],'o',markersize=8, markerfacecolor=c, markeredgecolor='k',markeredgewidth=2)
                     plt.plot(x[v>1], y[v>1],'o',markersize=8, markerfacecolor=c, markeredgecolor=c, markeredgewidth=2)
-
-                if draw_bbox:
-                    [bbox_x, bbox_y, bbox_w, bbox_h] = ann['bbox']
-                    poly = [[bbox_x, bbox_y], [bbox_x, bbox_y+bbox_h], [bbox_x+bbox_w, bbox_y+bbox_h], [bbox_x+bbox_w, bbox_y]]
-                    np_poly = np.array(poly).reshape((4,2))
-                    polygons.append(Polygon(np_poly))
-                    color.append(c)
-
             p = PatchCollection(polygons, facecolor=color, linewidths=0, alpha=0.4)
             ax.add_collection(p)
             p = PatchCollection(polygons, facecolor='none', edgecolors=color, linewidths=2)
@@ -313,7 +306,13 @@ class COCO:
 
         print('Loading and preparing results...')
         tic = time.time()
-        if type(resFile) == str or (PYTHON_VERSION == 2 and type(resFile) == unicode):
+
+        # Check result type in a way compatible with Python 2 and 3.
+        if PYTHON_VERSION == 2:
+            is_string =  isinstance(resFile, basestring)  # Python 2
+        elif PYTHON_VERSION == 3:
+            is_string = isinstance(resFile, str)  # Python 3
+        if is_string:
             anns = json.load(open(resFile))
         elif type(resFile) == np.ndarray:
             anns = self.loadNumpyAnnotations(resFile)

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -1,37 +1,26 @@
-from setuptools import dist, setup, Extension
-# To compile and install locally run "python setup.py build_ext --inplace"
-# To install library to Python site-packages run "python setup.py build_ext install"
-
-
-setup_requires=[
-    'setuptools>=18.0',
-    'cython>=0.27.3',
-    'numpy',
-]
-dist.Distribution().fetch_build_eggs(setup_requires)
-
+from distutils.core import setup
+from Cython.Build import cythonize
+from distutils.extension import Extension
 import numpy as np
+
+# To install and compile to your anaconda/python site-packages, simply run:
+# $ pip install git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI
+# Note that the original compile flags below are GCC flags unsupported by the Visual C++ 2015 build tools.
+# They can safely be removed.
 
 ext_modules = [
     Extension(
         'pycocotools._mask',
-        sources=['./common/maskApi.c', 'pycocotools/_mask.pyx'],
-        include_dirs = [np.get_include(), './common'],
-        extra_compile_args=['-Wno-cpp', '-Wno-unused-function', '-std=c99'],
+        sources=['../common/maskApi.c', 'pycocotools/_mask.pyx'],
+        include_dirs = [np.get_include(), '../common'],
+        extra_compile_args=[] # originally was ['-Wno-cpp', '-Wno-unused-function', '-std=c99'],
     )
 ]
 
-setup(
-    name='pycocotools',
-    description='Official APIs for the MS-COCO dataset',
-    packages=['pycocotools'],
-    package_dir = {'pycocotools': 'pycocotools'},
-    setup_requires=setup_requires,
-    install_requires=[
-        'setuptools>=18.0',
-        'cython>=0.27.3',
-        'matplotlib>=2.1.0'
-    ],
-    version='2.0.1',
-    ext_modules= ext_modules
-)
+setup(name='pycocotools',
+      packages=['pycocotools'],
+      package_dir = {'pycocotools': 'pycocotools'},
+      version='2.0',
+      ext_modules=
+          cythonize(ext_modules)
+      )


### PR DESCRIPTION
A PR as an outcome of the discussion at `facebookresearch/detectron2`- [#1712(comment)](https://github.com/facebookresearch/detectron2/issues/1712#issuecomment-670996808).

Changed the scripts - 
`PythonAPI/setup.py`
`PythonAPI/pycocotools/coco.py`

to the corresponding scripts modified in [philferriere's repo](https://github.com/philferriere/cocoapi) to add support for windows in pycocotools build.

To build pycocotools-
```python
$ pip install cython, numpy
$ cd PythonAPI
$ python setup.py build install
```

This installs pycocotools version `2.0`.