### PR TITLE
getAnnIds: areaRng not inclusive of limits

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -148,7 +148,7 @@ class COCO:
             else:
                 anns = self.dataset['annotations']
             anns = anns if len(catIds)  == 0 else [ann for ann in anns if ann['category_id'] in catIds]
-            anns = anns if len(areaRng) == 0 else [ann for ann in anns if ann['area'] > areaRng[0] and ann['area'] < areaRng[1]]
+            anns = anns if len(areaRng) == 0 else [ann for ann in anns if ann['area'] >= areaRng[0] and ann['area'] < areaRng[1]]
         if not iscrowd == None:
             ids = [ann['id'] for ann in anns if ann['iscrowd'] == iscrowd]
         else:


### PR DESCRIPTION
If you were to query annotations within a particular area range, via the `getAnnIds` function, it ignores those objects that have areas equal to the limits.

For example,

```
# Assuming objects areas only lie between 10^2 and 1e5^2 pixels

areaRng = [10,32,64,96]

small    = len(ann.getAnnIds(areaRng=[(areaRng[0]**2) , areaRng[1]**2]))
medium   = len(ann.getAnnIds(areaRng=[(areaRng[1]**2) , areaRng[2]**2]))
large    = len(ann.getAnnIds(areaRng=[(areaRng[2]**2) , areaRng[3]**2]))
total = len(ann.getAnnIds(areaRng=[(areaRng[0]**2), (areaRng[3]**2)]))

assert total = small + medium + large
```
The assertion would fail if there are objects that have area **exactly equal to** 10^2, 32^2, 64^2 or 96 ^2 pixels.