### PR TITLE
Revamp Python build system to fix multiple build problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,7 @@ jobs:
     steps:
       - checkout
       - run:
-          # TODO in-place pip install is not working
-          command: cd PythonAPI && python setup.py build_ext
+          command: python -m pip install --use-feature=in-tree-build ./PythonAPI
           name: Install From Source
 
   build-from-sdist:
@@ -19,8 +18,9 @@ jobs:
       - checkout
       - run:
           command: |
-            cd PythonAPI && python setup.py sdist
-            python -m pip install --progress-bar off dist/*.tar.gz
+            python -m pip install build
+            python -m build --sdist ./PythonAPI
+            python -m pip install --progress-bar off ./PythonAPI/dist/*.tar.gz
           name: Install From Distribution
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,10 @@ jobs:
       - run:
           command: python -m pip install --use-feature=in-tree-build ./PythonAPI
           name: Install From Source
+      - run:
+          command: |
+            python tests/test_cases.py
+          name: Run Simple Test Cases
 
   build-from-sdist:
     executor: python/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ jobs:
       - run:
           command: python -m pip install --use-feature=in-tree-build ./PythonAPI
           name: Install From Source
-      - run:
-          command: |
-            python tests/test_cases.py
-          name: Run Simple Test Cases
 
   build-from-sdist:
     executor: python/default

--- a/PythonAPI/Makefile
+++ b/PythonAPI/Makefile
@@ -5,5 +5,5 @@ all:
 
 install:
 	# install pycocotools to the Python site-packages
-	python setup.py build_ext install
+	python -m pip install --use-feature=in-tree-build .
 	rm -rf build

--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "cython>=0.27.3",
+    "oldest-supported-numpy",
+    "setuptools>=43.0.0",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -1,15 +1,8 @@
 """To compile and install locally run "python setup.py build_ext --inplace".
-To install library to Python site-packages run "python setup.py build_ext install"
+To install library to Python site-packages run "python -m pip install --use-feature=in-tree-build ."
 """
 import platform
-from setuptools import dist, setup, Extension
-
-setup_requires = [
-    'setuptools>=18.0',
-    'cython>=0.27.3',
-    'numpy',
-]
-dist.Distribution().fetch_build_eggs(setup_requires)
+from setuptools import setup, Extension
 
 import numpy as np
 
@@ -30,11 +23,10 @@ setup(
     license="FreeBSD",
     packages=['pycocotools'],
     package_dir={'pycocotools': 'pycocotools'},
-    setup_requires=setup_requires,
+    python_requires='>=3.5',
     install_requires=[
-        'setuptools>=18.0',
-        'cython>=0.27.3',
-        'matplotlib>=2.1.0'
+        'matplotlib>=2.1.0',
+        'numpy',
     ],
     version='2.0.2',
     ext_modules=ext_modules


### PR DESCRIPTION
Use `pyproject.toml` to define build metadata. This enables the following improvements:

* `pycocotools.mask` previously failed to load if the NumPy version was downgraded after `pycocotools` was installed, due to an ABI mismatch. This is fixed by using the oldest supported NumPy version for the current environment as the build dependency.

* Installing `pycocotools` no longer installs Cython as a dependency (it's not needed at runtime).

* `pycocotools` can now be installed without having `setuptools` in your environment.

All this is accomplished at the price of more strict system requirements:

* Required Python version is now 3.5+, primarily because that is what `oldest-supported-numpy` requires. Notably, this means that Python 2 support is dropped.

* pip 10 or higher is required to install `pycocotools` from an sdist.

The setuptools requirement is bumped to 43, because setuptools includes pyproject.toml in the sdist starting with this version. However, this has no impact on users, since pip will automatically fetch the correct version.

Additionally, update the documentation to recommend using `pip` to install the project, instead of running `setup.py` directly. This ensures that the build result is the same as you would get by installing from an sdist. pip 21.1+ is required for this, because it uses the `in-tree-build` feature.