### PR TITLE
Fix incompatibility with Cython 3.0.0a10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,28 @@ orbs:
   python: circleci/python@0.2.1
 
 jobs:
-  build-from-source:
+  build-from-source-cython2:
     executor: python/default
     steps:
       - checkout
       - run:
-          command: python -m pip install --use-feature=in-tree-build ./PythonAPI
+          command: |
+            python -m pip install Cython==0.29
+            python -m pip install --use-feature=in-tree-build ./PythonAPI
+          name: Install From Source
+      - run:
+          command: |
+            python tests/test_cases.py
+          name: Run Simple Test Cases
+          
+  build-from-source-cython3:
+    executor: python/default
+    steps:
+      - checkout
+      - run:
+          command: |
+            python -m pip install Cython==3.0.0a10
+            python -m pip install --use-feature=in-tree-build ./PythonAPI
           name: Install From Source
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,5 +50,6 @@ jobs:
 workflows:
   main:
     jobs:
-      - build-from-source
+      - build-from-source-cython2
+      - build-from-source-cython3
       - build-from-sdist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             python tests/test_cases.py
           name: Run Simple Test Cases
 
-  build-from-sdist:
+  build-from-sdist-cython2:
     executor: python/default
     steps:
       - checkout
@@ -40,6 +40,23 @@ jobs:
           command: |
             python -m pip install build
             python -m build --sdist ./PythonAPI
+            python -m pip install 'Cython<3' -U
+            python -m pip install --progress-bar off ./PythonAPI/dist/*.tar.gz
+          name: Install From Distribution
+      - run:
+          command: |
+            python tests/test_cases.py
+          name: Run Simple Test Cases
+          
+  build-from-sdist-cython3:
+    executor: python/default
+    steps:
+      - checkout
+      - run:
+          command: |
+            python -m pip install build
+            python -m build --sdist ./PythonAPI
+            python -m pip install 'Cython==3.0.0a10' -U
             python -m pip install --progress-bar off ./PythonAPI/dist/*.tar.gz
           name: Install From Distribution
       - run:
@@ -52,4 +69,5 @@ workflows:
     jobs:
       - build-from-source-cython2
       - build-from-source-cython3
-      - build-from-sdist
+      - build-from-sdist-cython2
+      - build-from-sdist-cython3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - run:
           command: |
-            python -m pip install Cython<3
+            python -m pip install 'Cython<3'
             python -m pip install --use-feature=in-tree-build ./PythonAPI
           name: Install From Source
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - run:
           command: |
-            python -m pip install Cython==0.29
+            python -m pip install Cython<3
             python -m pip install --use-feature=in-tree-build ./PythonAPI
           name: Install From Source
       - run:

--- a/PythonAPI/pycocotools/_mask.pyx
+++ b/PythonAPI/pycocotools/_mask.pyx
@@ -1,5 +1,4 @@
 # distutils: language = c
-# distutils: sources = ../common/maskApi.c
 
 #**************************************************************************
 # Microsoft COCO Toolbox.      version 2.0

--- a/PythonAPI/pycocotools/_mask.pyx
+++ b/PythonAPI/pycocotools/_mask.pyx
@@ -7,7 +7,6 @@
 # Licensed under the Simplified BSD License [see coco/license.txt]
 #**************************************************************************
 
-
 __author__ = 'tsungyi'
 
 import sys

--- a/PythonAPI/pycocotools/_mask.pyx
+++ b/PythonAPI/pycocotools/_mask.pyx
@@ -7,6 +7,7 @@
 # Licensed under the Simplified BSD License [see coco/license.txt]
 #**************************************************************************
 
+
 __author__ = 'tsungyi'
 
 import sys


### PR DESCRIPTION
In this alpha release of Cython 3, the behavior of `Cython.Distutils.build_ext` has changed, and now the `distutils: sources`
directive in `_mask.pyx` is interpreted. This means that `maskApi.c` is added to the extension twice (first by `setup.py`, second by `_mask.pyx`), so it's built twice and then linking fails due to multiple symbol definitions.

If the project is built from an sdist, the reference to `../common/maskApi.c` refers to a nonexistent file (note: the path is interpreted relative to the project, not relative to `_mask.pyx`), so the build also fails, but in a different way.

Remove the redundant directive to fix this.
