### PR TITLE
Numpy>=1.20.0

### DIFF
--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -26,7 +26,7 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'matplotlib>=2.1.0',
-        'numpy',
+        'numpy>=1.20.0',
     ],
     version='2.0.4',
     ext_modules=ext_modules


### PR DESCRIPTION
`1.19.5` gives a `ValueError`

```py
  File "/home/USER/src/detectron2/detectron2/structures/masks.py", line 6, in <module>
    import pycocotools.mask as mask_util
  File "/home/USER/.local/lib/python3.8/site-packages/pycocotools/mask.py", line 3, in <module>
    import pycocotools._mask as _mask
  File "pycocotools/_mask.pyx", line 1, in init pycocotools._mask
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```
This is fixed from `1.20.X`