### PR TITLE
Add attribute `annotation_file` for `COCO`

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -69,16 +69,16 @@ class COCO:
         """
         Constructor of Microsoft COCO helper class for reading and visualizing annotations.
         :param annotation_file (str): location of annotation file
-        :param image_folder (str): location to the folder that hosts images.
         :return:
         """
         # load dataset
         self.dataset,self.anns,self.cats,self.imgs = dict(),dict(),dict(),dict()
         self.imgToAnns, self.catToImgs = defaultdict(list), defaultdict(list)
-        if not annotation_file == None:
+        self.annotation_file = annotation_file
+        if self.annotation_file is not None:
             print('loading annotations into memory...')
             tic = time.time()
-            with open(annotation_file, 'r') as f:
+            with open(self.annotation_file, 'r') as f:
                 dataset = json.load(f)
             assert type(dataset)==dict, 'annotation file format {} not supported'.format(type(dataset))
             print('Done (t={:0.2f}s)'.format(time.time()- tic))


### PR DESCRIPTION
This patch adds `annotation_file` attribute for `COCO` class, so that it
could be easy to identify the original location of the dataset.