### PR TITLE
ci: add github-workflow to matrix-build wheels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Build Wheel
+      run: python -m pip wheel --no-deps ./PythonAPI
+    - name: Upload build output
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-output
+        path: ${{ github.workspace }}/*.whl
+        retention-days: 1
+        if-no-files-found: error


### PR DESCRIPTION
Hello,

As alot of people would want to use wheels from pypi I'm proposing switching to github-ci and using its matrix-build feature to generate wheels for all python-versions and operating-systems.

The contained github-workflow demonstrates how to do that.

Parts that are missing, as i first wanted to collect your input on this before going forward are:
- a job for running tests
- a job for publishing to pypi

I'm looking forward to hearing back from you