### PR TITLE
fix: take compiler-warning seriously

### DIFF
--- a/PythonAPI/pycocotools/_mask.pyx
+++ b/PythonAPI/pycocotools/_mask.pyx
@@ -210,12 +210,13 @@ def iou( dt, gt, pyiscrowd ):
     # convert iscrowd to numpy array
     cdef np.ndarray[np.uint8_t, ndim=1] iscrowd = np.array(pyiscrowd, dtype=np.uint8)
     # simple type checking
-    cdef siz m, n
+    cdef siz m, n, crowd_length
     dt = _preproc(dt)
     gt = _preproc(gt)
     m = _len(dt)
     n = _len(gt)
-    assert len(pyiscrowd) == n, "iou(iscrowd=) must have the same length as gt"
+    crowd_length = len(pyiscrowd)
+    assert crowd_length == n, "iou(iscrowd=) must have the same length as gt"
     if m == 0 or n == 0:
         return []
     if not type(dt) == type(gt):

--- a/common/maskApi.c
+++ b/common/maskApi.c
@@ -148,7 +148,7 @@ void bbNms( BB dt, siz n, uint *keep, double thr ) {
 
 void rleToBbox( const RLE *R, BB bb, siz n ) {
   siz i; for( i=0; i<n; i++ ) {
-    uint h, w, xs, ys, xe, ye, xp, cc; siz j, m;
+    uint h, w, xs, ys, xe, ye, cc; siz j, m;
     h=(uint)R[i].h; w=(uint)R[i].w; m=R[i].m;
     m=((siz)(m/2))*2; xs=w; ys=h; xe=ye=0; cc=0;
     if(m==0) { bb[4*i+0]=bb[4*i+1]=bb[4*i+2]=bb[4*i+3]=0; continue; }
@@ -194,8 +194,10 @@ void rleFrPoly( RLE *R, const double *xy, siz k, siz h, siz w ) {
   /* upsample and get discrete points densely along entire boundary */
   siz j, m=0; double scale=5; int *x, *y, *u, *v; uint *a, *b;
   x=malloc(sizeof(int)*(k+1)); y=malloc(sizeof(int)*(k+1));
-  for(j=0; j<k; j++) x[j]=(int)(scale*xy[j*2+0]+.5); x[k]=x[0];
-  for(j=0; j<k; j++) y[j]=(int)(scale*xy[j*2+1]+.5); y[k]=y[0];
+  for(j=0; j<k; j++) x[j]=(int)(scale*xy[j*2+0]+.5);
+  x[k]=x[0];
+  for(j=0; j<k; j++) y[j]=(int)(scale*xy[j*2+1]+.5);
+  y[k]=y[0];
   for(j=0; j<k; j++) m+=umax(abs(x[j]-x[j+1]),abs(y[j]-y[j+1]))+1;
   u=malloc(sizeof(int)*m); v=malloc(sizeof(int)*m); m=0;
   for( j=0; j<k; j++ ) {
@@ -240,7 +242,8 @@ char* rleToString( const RLE *R ) {
     x=(long) R->cnts[i]; if(i>2) x-=(long) R->cnts[i-2]; more=1;
     while( more ) {
       char c=x & 0x1f; x >>= 5; more=(c & 0x10) ? x!=-1 : x!=0;
-      if(more) c |= 0x20; c+=48; s[p++]=c;
+      if(more) c |= 0x20;
+      c+=48; s[p++]=c;
     }
   }
   s[p]=0; return s;
@@ -248,7 +251,8 @@ char* rleToString( const RLE *R ) {
 
 void rleFrString( RLE *R, char *s, siz h, siz w ) {
   siz m=0, p=0, k; long x; int more; uint *cnts;
-  while( s[m] ) m++; cnts=malloc(sizeof(uint)*m); m=0;
+  while( s[m] ) m++;
+  cnts=malloc(sizeof(uint)*m); m=0;
   while( s[p] ) {
     x=0; k=0; more=1;
     while( more ) {
@@ -256,7 +260,8 @@ void rleFrString( RLE *R, char *s, siz h, siz w ) {
       more = c & 0x20; p++; k++;
       if(!more && (c & 0x10)) x |= -1 << 5*k;
     }
-    if(m>2) x+=(long) cnts[m-2]; cnts[m++]=(uint) x;
+    if(m>2) x+=(long) cnts[m-2];
+    cnts[m++]=(uint) x;
   }
   rleInit(R,h,w,m,cnts); free(cnts);
 }


### PR DESCRIPTION
@ppwwyyxx This is a small fix and just take compiler(gcc) warning seriously.
Using command like `pip install -v -e .` under PythonAPI directory could reproduce the compiler warning.