### PR TITLE
Make 'image_id' a string for annsImgIds list

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -323,7 +323,7 @@ class COCO:
         else:
             anns = resFile
         assert type(anns) == list, 'results in not an array of objects'
-        annsImgIds = [ann['image_id'] for ann in anns]
+        annsImgIds = [str(ann['image_id']) for ann in anns]
         assert set(annsImgIds) == (set(annsImgIds) & set(self.getImgIds())), \
                'Results do not correspond to current coco set'
         if 'caption' in anns[0]:


### PR DESCRIPTION
If, for any reason, 'image_id' is made of an integer only, it can be read as such in the 'anns' dictionary. So, it becomes inconsistent with a self.getImgIds() call that returns a string all the time. So, the 'assert' check on the 327th line fails in a similar scenario. This modification ensures they are aligned.