### PR TITLE
Missing maxDets argument pass

### DIFF
--- a/PythonAPI/pycocotools/cocoeval.py
+++ b/PythonAPI/pycocotools/cocoeval.py
@@ -457,7 +457,7 @@ class COCOeval:
             return mean_s
         def _summarizeDets():
             stats = np.zeros((12,))
-            stats[0] = _summarize(1)
+            stats[0] = _summarize(1, maxDets=self.params.maxDets[2])
             stats[1] = _summarize(1, iouThr=.5, maxDets=self.params.maxDets[2])
             stats[2] = _summarize(1, iouThr=.75, maxDets=self.params.maxDets[2])
             stats[3] = _summarize(1, areaRng='small', maxDets=self.params.maxDets[2])


### PR DESCRIPTION
I think since the '_summarize' function expects a _maxDets_ argument and a user is allowed to specify _params.maxDets_, it is crucial to pass it; otherwise, it is going to always use a default _maxDets=100_ when computing **mAP0.5-0.95**.