### PR TITLE
Wheel files that support numpy 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,10 @@ jobs:
         uses: pypa/cibuildwheel@v2.16
         env:
           CIBW_BUILD_FRONTEND: build
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_SKIP: "pp* *musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_BEFORE_TEST: pip install --force-reinstall numpy
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py
         with:
           package-dir: ./PythonAPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,11 @@ jobs:
             cibw_archs: universal2
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         if: matrix.cibw_archs == 'aarch64'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
@@ -39,8 +39,9 @@ jobs:
         with:
           package-dir: ./PythonAPI
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: pycocotools-${{ matrix.os }}-${{ matrix.cibw_archs }}
           path: ./wheelhouse/*.whl
 
   test_source:
@@ -51,13 +52,14 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build sdist
         run: pipx run build --sdist ./PythonAPI
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: pycocotools-sdist
           path: ./PythonAPI/dist/*.tar.gz
 
   publish:
@@ -71,10 +73,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
           path: dist
+          merge-multiple: true
 
       - name: Display structure of downloaded files
         run: ls -R dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,12 @@ jobs:
           platforms: arm64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16
+        uses: pypa/cibuildwheel@v2.17
         env:
           CIBW_BUILD_FRONTEND: build
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
-          CIBW_SKIP: "pp* *musllinux*"
+          CIBW_SKIP: "pp*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_BEFORE_TEST: pip install --force-reinstall numpy
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py
         with:
           package-dir: ./PythonAPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             cibw_archs: aarch64
           - os: windows-latest
             cibw_archs: auto64
-          - os: macos-latest
+          - os: macos-14
             cibw_archs: universal2
 
     steps:
@@ -29,10 +29,10 @@ jobs:
           platforms: arm64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.14
+        uses: pypa/cibuildwheel@v2.16
         env:
           CIBW_BUILD_FRONTEND: build
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
           CIBW_SKIP: "pp* *musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -16,6 +16,9 @@ jobs:
           - os: ubuntu-latest # linux arm64 gnu
             cibw_archs: aarch64
             cibw_skip: "pp* *musllinux*"
+          - os: ubuntu-latest # linux arm64 musl
+            cibw_archs: aarch64
+            cibw_skip: "pp* *manylinux*"
           - os: windows-latest
             cibw_archs: AMD64 ARM64
             cibw_skip: "pp*"
@@ -40,12 +43,13 @@ jobs:
           CIBW_SKIP: ${{ matrix.cibw_skip }}
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py
+          CIBW_TEST_SKIP: "*-win_arm64 *-musllinux_aarch64"
         with:
           package-dir: ./PythonAPI
 
       - uses: actions/upload-artifact@v4
         with:
-          name: pycocotools-${{ matrix.os }}-${{ matrix.cibw_archs }}
+          name: pycocotools-${{ matrix.os }}-${{ matrix.cibw_archs }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   test_source:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,30 +10,34 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            cibw_archs: auto64
-          - os: ubuntu-latest
+          - os: ubuntu-latest # linux x86_64
+            cibw_archs: x86_64
+            cibw_skip: "pp*"
+          - os: ubuntu-latest # linux arm64 gnu
             cibw_archs: aarch64
+            cibw_skip: "pp* *musllinux*"
           - os: windows-latest
-            cibw_archs: auto64
+            cibw_archs: AMD64 ARM64
+            cibw_skip: "pp*"
           - os: macos-14
             cibw_archs: universal2
+            cibw_skip: "pp*"
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: matrix.cibw_archs == 'aarch64'
+        if: runner.os == 'Linux' && matrix.cibw_archs == 'aarch64'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
-      - name: Build wheels
+      - name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
         uses: pypa/cibuildwheel@v2.17
         env:
           CIBW_BUILD_FRONTEND: build
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
-          CIBW_SKIP: "pp*"
+          CIBW_SKIP: ${{ matrix.cibw_skip }}
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py
         with:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -28,18 +28,16 @@ jobs:
 
       - name: Install from source
         if: matrix.install_from == 'source'
-        run: pip install ./PythonAPI
+        run: |
+          pip install ./PythonAPI '${{ matrix.numpy }}'
+          python -c "import numpy as np; print(np.__version__)"
 
       - name: Install from sdist
         if: matrix.install_from == 'sdist'
         shell: bash
         run: |
           pipx run build --sdist ./PythonAPI
-          pip install ./PythonAPI/dist/*.tar.gz
-
-      - name: Install numpy
-        run: |
-          pip install '${{ matrix.numpy }}'
+          pip install ./PythonAPI/dist/*.tar.gz '${{ matrix.numpy }}'
           python -c "import numpy as np; print(np.__version__)"
 
       - name: Run test cases

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.9"
 
       - name: Fix windows symlink
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,12 +7,13 @@ on:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}, ${{ matrix.install_from }}
+    name: Test on ${{ matrix.os }}, ${{ matrix.install_from }}, ${{ matrix.numpy }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        install_from: [source, source_with_pre, sdist]
+        install_from: [source, sdist]
+        numpy: [oldest-supported-numpy, numpy<2, numpy>=2.0.0rc1]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,17 +30,17 @@ jobs:
         if: matrix.install_from == 'source'
         run: pip install ./PythonAPI
 
-      - name: Install from source with prerelease.
-        if: matrix.install_from == 'source_with_pre'
-        # This tests compatibility with pre-release dependencies
-        run: pip install --pre ./PythonAPI
-
       - name: Install from sdist
         if: matrix.install_from == 'sdist'
         shell: bash
         run: |
           pipx run build --sdist ./PythonAPI
           pip install ./PythonAPI/dist/*.tar.gz
+
+      - name: Install numpy
+        run: |
+          pip install '${{ matrix.numpy }}'
+          python -c "import numpy as np; print(np.__version__)"
 
       - name: Run test cases
         run: python tests/test_cases.py

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -15,8 +15,8 @@ jobs:
         install_from: [source, source_with_pre, sdist]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cython>=0.27.3",
-    "numpy>=2.0.0b1",
+    "numpy>=2.0.0rc1",
     "setuptools>=43.0.0",
     "wheel",
 ]

--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cython>=0.27.3",
-    "numpy>=1.25",
+    "numpy>=2.0.0b1",
     "setuptools>=43.0.0",
     "wheel",
 ]

--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cython>=0.27.3",
-    "oldest-supported-numpy",
+    "numpy>=1.25",
     "setuptools>=43.0.0",
     "wheel",
 ]

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -32,7 +32,7 @@ setup(
     license="FreeBSD",
     packages=['pycocotools'],
     package_dir={'pycocotools': 'pycocotools'},
-    python_requires='>=3.5',
+    python_requires='>=3.9',
     install_requires=[
         'matplotlib>=2.1.0',
         'numpy',


### PR DESCRIPTION
numpy is approaching its 2.0 release.
https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice

According to numpy's documentation, packages built with numpy 2.0 will work with numpy 1.x, so modifying the build requirements to numpy 2.0 should be fine.

In addition, I've updated to support more platforms. 