### PR TITLE
COCO.loadRes: copy the info dict to the results too

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -311,6 +311,7 @@ class COCO:
         :return: res (obj)         : result api object
         """
         res = COCO()
+        res.dataset['info'] = copy.deepcopy(self.dataset['info'])
         res.dataset['images'] = [img for img in self.dataset['images']]
 
         print('Loading and preparing results...')


### PR DESCRIPTION
The `COCO.loadRes` returns a new `COCO` object with the results. It does this by copying the images and categories fields from the COCO data object. However, it does not copy the `info` dict. The end result is that the `info()` method in the returned results COCO fails:

```
>>> coco_res = coco_data.loadRes(...)
>>> coco_res.info()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/pycocotools/coco.py", line 124, in info
    for key, value in self.dataset['info'].items():
                      ~~~~~~~~~~~~^^^^^^^^
KeyError: 'info'
```

ThIs PR copies the original `info` field so things work. I'm not sure if it is the best choice since the results should maybe have a different "info" but there is no "info" on the results file so this seems the best option to prevent errors without changing the API.