### PR TITLE
~~Build abi3 wheel for python 3.13, 3.14...~~ and build modernizing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,16 +32,11 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_ENABLE: cpython-freethreading
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-            auditwheel repair -w {dest_dir} {wheel} &&
-            uvx abi3audit --strict --report {wheel}
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} &&
-            uvx abi3audit --strict --report {wheel}
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
-            uvx abi3audit --strict --report {wheel}
         with:
           package-dir: ./PythonAPI
+
+      - name: Run abi3audit
+        run: uvx abi3audit --report ./wheelhouse/*-abi3-*.whl
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,15 +32,14 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_ENABLE: cpython-freethreading
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py
-          CIBW_BEFORE_BUILD: pip install abi3audit
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel repair -w {dest_dir} {wheel} &&
-            abi3audit --strict --report {wheel}
+            uvx abi3audit --strict --report {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} &&
-            abi3audit --strict --report {wheel}
+            uvx abi3audit --strict --report {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
-            abi3audit --strict --report {wheel}
+            uvx abi3audit --strict --report {wheel}
         with:
           package-dir: ./PythonAPI
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           package-dir: ./PythonAPI
 
-      - name: Run abi3audit
-        run: uvx abi3audit --report ./wheelhouse/*-abi3-*.whl
-
       - uses: actions/upload-artifact@v4
         with:
           name: pycocotools-${{ matrix.os }}-${{ matrix.cibw_archs }}-${{ strategy.job-index }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,40 +10,32 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest # linux x86_64
+          - os: ubuntu-latest
             cibw_archs: x86_64
             cibw_skip: "pp*"
-          - os: ubuntu-latest # linux arm64 gnu
+          - os: ubuntu-24.04-arm
             cibw_archs: aarch64
-            cibw_skip: "pp* *musllinux*"
-          - os: ubuntu-latest # linux arm64 musl
-            cibw_archs: aarch64
-            cibw_skip: "pp* *manylinux*"
+            cibw_skip: "pp*"
           - os: windows-latest
             cibw_archs: AMD64 ARM64
             cibw_skip: "pp*"
-          - os: macos-14
+          - os: macos-latest
             cibw_archs: universal2
             cibw_skip: "pp*"
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux' && matrix.cibw_archs == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
+      - uses: astral-sh/setup-uv@v6
 
       - name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
-        uses: pypa/cibuildwheel@v2.17
+        uses: pypa/cibuildwheel@v2.23
         env:
-          CIBW_BUILD_FRONTEND: build
+          CIBW_BUILD_FRONTEND: build[uv]
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_SKIP: ${{ matrix.cibw_skip }}
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py
-          CIBW_TEST_SKIP: "*-win_arm64 *-musllinux_aarch64"
+          CIBW_ENABLE: cpython-freethreading
         with:
           package-dir: ./PythonAPI
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,34 +11,42 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        install_from: [source, sdist]
-        numpy: [oldest-supported-numpy, numpy<2, numpy>=2.0.0rc1]
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+          - windows-latest
+        install_from:
+          - source
+          - sdist
+        numpy:
+          - oldest-supported-numpy
+          - numpy>=2.0.0
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
+      - uses: astral-sh/setup-uv@v6
 
       - name: Fix windows symlink
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         shell: bash
         run: rm ./PythonAPI/common && cp -r ./common ./PythonAPI
 
-      - name: Install from source
+      - name: Test from source
         if: matrix.install_from == 'source'
+        shell: bash
         run: |
-          pip install ./PythonAPI '${{ matrix.numpy }}'
-          python -c "import numpy as np; print(np.__version__)"
+          for version in 3.9 3.10 3.11 3.12 3.13 3.13t
+          do
+            uv run --with ./PythonAPI --with '${{ matrix.numpy }}' --python $version --managed-python tests/test_cases.py
+          done
 
-      - name: Install from sdist
+      - name: Test from sdist
         if: matrix.install_from == 'sdist'
         shell: bash
         run: |
-          pipx run build --sdist ./PythonAPI
-          pip install ./PythonAPI/dist/*.tar.gz '${{ matrix.numpy }}'
-          python -c "import numpy as np; print(np.__version__)"
-
-      - name: Run test cases
-        run: python tests/test_cases.py
+          uv build --sdist ./PythonAPI
+          for version in 3.9 3.10 3.11 3.12 3.13 3.13t
+          do
+            uv run --with ./PythonAPI/dist/*.tar.gz --with '${{ matrix.numpy }}' --python $version --managed-python tests/test_cases.py
+          done

--- a/PythonAPI/MANIFEST.in
+++ b/PythonAPI/MANIFEST.in
@@ -1,1 +1,3 @@
 graft ./common
+include **/_mask.pyx
+exclude **/_mask.c

--- a/PythonAPI/MANIFEST.in
+++ b/PythonAPI/MANIFEST.in
@@ -1,3 +1,3 @@
 graft ./common
-include **/_mask.pyx
-exclude **/_mask.c
+exclude **/*mask.c
+include **/*mask.pyx

--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -311,6 +311,7 @@ class COCO:
         :return: res (obj)         : result api object
         """
         res = COCO()
+        res.dataset['info'] = copy.deepcopy(self.dataset['info'])
         res.dataset['images'] = [img for img in self.dataset['images']]
 
         print('Loading and preparing results...')

--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "cython>=0.27.3",
-    "numpy>=2.0.0rc1",
+    "cython>=3.1.0",
+    "numpy>=2.0.0",
     "setuptools>=43.0.0",
     "wheel",
 ]

--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "cython>=3.1.0",
-    "numpy>=2.0.0",
-    "setuptools>=43.0.0",
-    "wheel",
+    "numpy>=2.0.0,<3",
+    "setuptools>=70.1.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -26,8 +26,6 @@ ext_modules = [
             'pycocotools._mask',
             sources=['./common/maskApi.c', 'pycocotools/_mask.pyx'],
             include_dirs=[np.get_include(), './common'],
-            extra_compile_args=[] if platform.system()=='Windows' else
-            ['-Wno-cpp', '-Wno-unused-function', '-std=c99'],
             **limited_api_args
         )
     ]

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from setuptools import setup, Extension
 
 import numpy as np
+from Cython.Build import cythonize
 
 ext_modules = [
         Extension(
@@ -38,5 +39,5 @@ setup(
         'numpy',
     ],
     version='2.0.8',
-    ext_modules=ext_modules
+    ext_modules=cythonize(ext_modules)
 )

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -2,6 +2,7 @@
 To install library to Python site-packages run "python -m pip install --use-feature=in-tree-build ."
 """
 import platform
+import sys
 import sysconfig
 from pathlib import Path
 from setuptools import setup, Extension
@@ -10,13 +11,13 @@ import numpy as np
 from Cython.Build import cythonize
 
 py_gil_disabled = sysconfig.get_config_var('Py_ENABLE_GIL')
-use_limited_api = not py_gil_disabled and platform.python_implementation() == 'CPython'
+use_limited_api = not py_gil_disabled and platform.python_implementation() == 'CPython' and sys.version_info >= (3, 11)
 if use_limited_api:
     limited_api_args = {
         "py_limited_api": True,
-        "define_macros": [("Py_LIMITED_API", "0x03090000")],
+        "define_macros": [("Py_LIMITED_API", "0x030B0000")],
     }
-    options = {"bdist_wheel": {"py_limited_api": "cp39"}}
+    options = {"bdist_wheel": {"py_limited_api": "cp311"}}
 else:
     limited_api_args = {}
     options = {}

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -11,13 +11,13 @@ import numpy as np
 from Cython.Build import cythonize
 
 py_gil_disabled = sysconfig.get_config_var('Py_GIL_DISABLED')
-use_limited_api = not py_gil_disabled and platform.python_implementation() == 'CPython' and sys.version_info >= (3, 11)
+use_limited_api = not py_gil_disabled and platform.python_implementation() == 'CPython' and sys.version_info >= (3, 12)
 if use_limited_api:
     limited_api_args = {
         "py_limited_api": True,
-        "define_macros": [("Py_LIMITED_API", "0x030B0000")],
+        "define_macros": [("Py_LIMITED_API", "0x030C0000")],
     }
-    options = {"bdist_wheel": {"py_limited_api": "cp311"}}
+    options = {"bdist_wheel": {"py_limited_api": "cp312"}}
 else:
     limited_api_args = {}
     options = {}

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -1,33 +1,17 @@
 """To compile and install locally run "python setup.py build_ext --inplace".
 To install library to Python site-packages run "python -m pip install --use-feature=in-tree-build ."
 """
-import platform
-import sys
-import sysconfig
 from pathlib import Path
 from setuptools import setup, Extension
 
 import numpy as np
 from Cython.Build import cythonize
 
-py_gil_disabled = sysconfig.get_config_var('Py_GIL_DISABLED')
-use_limited_api = not py_gil_disabled and platform.python_implementation() == 'CPython' and sys.version_info >= (3, 12)
-if use_limited_api:
-    limited_api_args = {
-        "py_limited_api": True,
-        "define_macros": [("Py_LIMITED_API", "0x030C0000")],
-    }
-    options = {"bdist_wheel": {"py_limited_api": "cp312"}}
-else:
-    limited_api_args = {}
-    options = {}
-
 ext_modules = [
         Extension(
             'pycocotools._mask',
             sources=['./common/maskApi.c', 'pycocotools/_mask.pyx'],
             include_dirs=[np.get_include(), './common'],
-            **limited_api_args
         )
     ]
 
@@ -54,5 +38,4 @@ setup(
     },
     version='2.0.9',
     ext_modules=cythonize(ext_modules),
-    options=options,
 )

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, Extension
 import numpy as np
 from Cython.Build import cythonize
 
-py_gil_disabled = sysconfig.get_config_var('Py_ENABLE_GIL')
+py_gil_disabled = sysconfig.get_config_var('Py_GIL_DISABLED')
 use_limited_api = not py_gil_disabled and platform.python_implementation() == 'CPython' and sys.version_info >= (3, 11)
 if use_limited_api:
     limited_api_args = {


### PR DESCRIPTION
Improves the project's build and test processes by adopting `uv` for dependency management and build abi3 wheel for future compatibility

- Migrates from `pip` and `pipx` to `uv` for faster and more efficient dependency resolution and package building.
- Introduces support for testing against multiple Python versions in the unit test workflow.
- Constrains numpy version and updates setuptools version.

---

![zen_p5hopBO0jn](https://github.com/user-attachments/assets/2e25ecd6-6836-4951-b240-aaa7ac939ad7)

As shown in the polars deployment above, deploying in the limited api format ensures that future versions of Python can continue to use the release. 

---

```yaml
        numpy:
          - oldest-supported-numpy
          - numpy>=2.0.0
```

I excluded numpy==1.26 because it takes a long time to build on newer versions of python and fails on freethreading python.

---

## Limited API wheel for python 3.12

The numpy limited api build requires python 3.11. (https://github.com/numpy/numpy/issues/26756#issuecomment-2180078335)

> If you are prepared to restrict yourself to Python versions 3.12+, then Cython will use the “vectorcall” interface in Limited API mode. This doesn’t enable any new functionality, but it does give a noticeable performance improvement. (Outside of the Limited API, Cython almost always uses this interface).

However, as the [Cython documentation](https://cython.readthedocs.io/en/latest/src/userguide/limited_api.html#performance) says, there are performance benefits when setting it to 3.12 or higher, I set the ABI to 3.12.



