### PR TITLE
Fix support for numpy 2.3+

### DIFF
--- a/PythonAPI/pycocotools/_mask.pyx
+++ b/PythonAPI/pycocotools/_mask.pyx
@@ -95,7 +95,7 @@ cdef class Masks:
         # Create a 1D array, and reshape it to fortran/Matlab column-major array
         ndarray = np.PyArray_SimpleNewFromData(1, shape, np.NPY_UINT8, self._mask).reshape((self._h, self._w, self._n), order='F')
         # The _mask allocated by Masks is now handled by ndarray
-        PyArray_ENABLEFLAGS(ndarray, np.NPY_OWNDATA)
+        PyArray_ENABLEFLAGS(ndarray, np.NPY_ARRAY_OWNDATA)
         return ndarray
 
 # internal conversion from Python RLEs object to compressed RLE format
@@ -164,7 +164,7 @@ def area(rleObjs):
     shape[0] = <np.npy_intp> Rs._n
     a = np.array((Rs._n, ), dtype=np.uint8)
     a = np.PyArray_SimpleNewFromData(1, shape, np.NPY_UINT32, _a)
-    PyArray_ENABLEFLAGS(a, np.NPY_OWNDATA)
+    PyArray_ENABLEFLAGS(a, np.NPY_ARRAY_OWNDATA)
     return a
 
 # iou computation. support function overload (RLEs-RLEs and bbox-bbox).
@@ -236,7 +236,7 @@ def iou( dt, gt, pyiscrowd ):
     iou = np.zeros((m*n, ), dtype=np.double)
     shape[0] = <np.npy_intp> m*n
     iou = np.PyArray_SimpleNewFromData(1, shape, np.NPY_DOUBLE, _iou)
-    PyArray_ENABLEFLAGS(iou, np.NPY_OWNDATA)
+    PyArray_ENABLEFLAGS(iou, np.NPY_ARRAY_OWNDATA)
     _iouFun(dt, gt, iscrowd, m, n, iou)
     return iou.reshape((m,n), order='F')
 
@@ -249,7 +249,7 @@ def toBbox( rleObjs ):
     shape[0] = <np.npy_intp> 4*n
     bb = np.array((1,4*n), dtype=np.double)
     bb = np.PyArray_SimpleNewFromData(1, shape, np.NPY_DOUBLE, _bb).reshape((n, 4))
-    PyArray_ENABLEFLAGS(bb, np.NPY_OWNDATA)
+    PyArray_ENABLEFLAGS(bb, np.NPY_ARRAY_OWNDATA)
     return bb
 
 def frBbox(np.ndarray[np.double_t, ndim=2] bb, siz h, siz w ):


### PR DESCRIPTION
`NPY_OWNDATA` was deprecated in numpy 1.7 (12 years ago) and will be removed in numpy 2.3 (https://github.com/numpy/numpy/releases/tag/v2.3.0rc1). This bug is already preventing building wheels for Python 3.13 right now, as pip automatically downloads and installs numpy 2.3.0rc1.

Same as https://github.com/cocodataset/cocoapi/pull/686

@isaaccorley