### PR TITLE
feat: build abi3 wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           package-dir: ./PythonAPI
 
+      - name: Run abi3audit
+        run: uvx abi3audit --report ./wheelhouse/*-abi3-*.whl
+
       - uses: actions/upload-artifact@v4
         with:
           name: pycocotools-${{ matrix.os }}-${{ matrix.cibw_archs }}-${{ strategy.job-index }}

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -1,17 +1,33 @@
 """To compile and install locally run "python setup.py build_ext --inplace".
 To install library to Python site-packages run "python -m pip install --use-feature=in-tree-build ."
 """
+import platform
+import sys
+import sysconfig
 from pathlib import Path
 from setuptools import setup, Extension
 
 import numpy as np
 from Cython.Build import cythonize
 
+py_gil_disabled = sysconfig.get_config_var('Py_GIL_DISABLED')
+use_limited_api = not py_gil_disabled and platform.python_implementation() == 'CPython' and sys.version_info >= (3, 12)
+if use_limited_api:
+    limited_api_args = {
+        "py_limited_api": True,
+        "define_macros": [("Py_LIMITED_API", "0x030C0000")],
+    }
+    options = {"bdist_wheel": {"py_limited_api": "cp312"}}
+else:
+    limited_api_args = {}
+    options = {}
+
 ext_modules = [
         Extension(
             'pycocotools._mask',
             sources=['./common/maskApi.c', 'pycocotools/_mask.pyx'],
             include_dirs=[np.get_include(), './common'],
+            **limited_api_args
         )
     ]
 
@@ -38,4 +54,5 @@ setup(
     },
     version='2.0.9',
     ext_modules=cythonize(ext_modules),
+    options=options,
 )


### PR DESCRIPTION
Continuing on from #27 

Build whl files using the limited api to ensure compatibility with future Python versions.

The following files are built, and for Python 3.12 and later versions, the cp312-abi3 file is used for installation (on non-freethreaded).

```sh
10 wheels produced in 3 minutes:
  pycocotools-2.0.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl    445 kB
  pycocotools-2.0.9-cp310-cp310-musllinux_1_2_x86_64.whl                          471 kB
  pycocotools-2.0.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl    467 kB
  pycocotools-2.0.9-cp311-cp311-musllinux_1_2_x86_64.whl                          496 kB
  pycocotools-2.0.9-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl     388 kB
  pycocotools-2.0.9-cp312-abi3-musllinux_1_2_x86_64.whl                           407 kB
  pycocotools-2.0.9-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   459 kB
  pycocotools-2.0.9-cp313-cp313t-musllinux_1_2_x86_64.whl                         476 kB
  pycocotools-2.0.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl      443 kB
  pycocotools-2.0.9-cp39-cp39-musllinux_1_2_x86_64.whl                            471 kB
```