### PR TITLE
Fix: Compute `maxX` and `maxY` to handle right/bottom mask edges

### DIFF
--- a/common/maskApi.c
+++ b/common/maskApi.c
@@ -193,10 +193,26 @@ int uintCompare(const void *a, const void *b) {
 void rleFrPoly( RLE *R, const double *xy, siz k, siz h, siz w ) {
   /* upsample and get discrete points densely along entire boundary */
   siz j, m=0; double scale=5; int *x, *y, *u, *v; uint *a, *b;
+
+  double maxX = -1e30, maxY = -1e30;
+  int maxXInt = 1, maxYInt = 1;
+  for (j = 0; j < k; j++) {
+    double xi = xy[j*2+0], yi = xy[j*2+1];
+    if (xi > maxX) maxX = xi;
+    if (yi > maxY) maxY = yi;
+  }
+  maxXInt = (floor(maxX) == maxX);
+  maxYInt = (floor(maxY) == maxY);
+
   x=malloc(sizeof(int)*(k+1)); y=malloc(sizeof(int)*(k+1));
-  for(j=0; j<k; j++) x[j]=(int)(scale*xy[j*2+0]+.5);
+  for(j=0; j<k; j++) {
+    double xi = xy[j*2+0], yi = xy[j*2+1];
+    if (maxXInt && xi == maxX && xi + 1 <= w) xi += 1;
+    if (maxYInt && yi == maxY && yi + 1 <= h) yi += 1;
+    x[j]=(int)(scale*xi+.5);
+    y[j]=(int)(scale*yi+.5);
+  }
   x[k]=x[0];
-  for(j=0; j<k; j++) y[j]=(int)(scale*xy[j*2+1]+.5);
   y[k]=y[0];
   for(j=0; j<k; j++) m+=umax(abs(x[j]-x[j+1]),abs(y[j]-y[j+1]))+1;
   u=malloc(sizeof(int)*m); v=malloc(sizeof(int)*m); m=0;


### PR DESCRIPTION
Fix off by one error in RLE generation.

https://github.com/cocodataset/cocoapi/issues/659