### PR TITLE
support Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
 
       - name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
-        uses: pypa/cibuildwheel@v2.23
+        uses: pypa/cibuildwheel@v3.1.4
         env:
           CIBW_BUILD_FRONTEND: build[uv]
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -36,7 +36,7 @@ jobs:
         if: matrix.install_from == 'source'
         shell: bash
         run: |
-          for version in 3.9 3.10 3.11 3.12 3.13 3.13t
+          for version in 3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
           do
             uv run --with ./PythonAPI --with '${{ matrix.numpy }}' --python $version --managed-python tests/test_cases.py
           done
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: |
           uv build --sdist ./PythonAPI
-          for version in 3.9 3.10 3.11 3.12 3.13 3.13t
+          for version in 3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
           do
             uv run --with ./PythonAPI/dist/*.tar.gz --with '${{ matrix.numpy }}' --python $version --managed-python tests/test_cases.py
           done


### PR DESCRIPTION
Enables CI and wheel uploads on 3.14 and 3.14t. For the wheel building workflow, see [this actions run](https://github.com/ngoldbaum/cocoapi/actions/runs/17080206793) on my fork. The failure was because my fork doesn't have permissions to actually upload the wheels, but everything else ran successfully.

cibuildwheel 3.1 automatically builds 3.14 and 3.14t wheels with no special configuration.

As far as I can tell no other changes are necessary but please let me know if you think I'm missing anything.