### PR TITLE
fix: added default value for info

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -311,7 +311,7 @@ class COCO:
         :return: res (obj)         : result api object
         """
         res = COCO()
-        res.dataset['info'] = copy.deepcopy(self.dataset['info'])
+        res.dataset['info'] = copy.deepcopy(self.dataset.get('info', {}))
         res.dataset['images'] = [img for img in self.dataset['images']]
 
         print('Loading and preparing results...')


### PR DESCRIPTION
This issues fixes the case when annotation file does not have `info` key.

```
  File "/home/lib/python3.11/site-packages/pycocotools/coco.py", line 316, in loadRes
    res.dataset['info'] = copy.deepcopy(self.dataset['info'])
                                        ~~~~~~~~~~~~^^^^^^^^
KeyError: 'info'


```

Since this key has metadata which not required in the actual training or evaluation process, AND is being used only for logging, `info` should not be a mandatory attribute of COCO annotations. 

Missing `info` should not throw an error.

Having an empty default value should be possible.
