### PR TITLE
Update cocoeval.py

### DIFF
--- a/PythonAPI/pycocotools/cocoeval.py
+++ b/PythonAPI/pycocotools/cocoeval.py
@@ -457,7 +457,7 @@ class COCOeval:
             return mean_s
         def _summarizeDets():
             stats = np.zeros((12,))
-            stats[0] = _summarize(1)
+            stats[0] = _summarize(1, maxDets=self.params.maxDets[2])
             stats[1] = _summarize(1, iouThr=.5, maxDets=self.params.maxDets[2])
             stats[2] = _summarize(1, iouThr=.75, maxDets=self.params.maxDets[2])
             stats[3] = _summarize(1, areaRng='small', maxDets=self.params.maxDets[2])


### PR DESCRIPTION
This is the same bug as https://github.com/cocodataset/cocoapi/issues/558#issuecomment-1944935682

I don't think this is a feature or intended behavior as suggested by https://github.com/cocodataset/cocoapi/issues/558#issuecomment-1944935682

For instance, if a user specifies `maxDets=[10, 20, 300]` to compute evaluation metrics, the statistics from `stats[1]` through `stats[11]` will be correctly computed using the intended number of detections. However, stats[0] will yield incorrect results because, as seen on [line 436 ](https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/cocoeval.py#L436), it relies on an empty mind array—leading to undefined or misleading output for that metric. 

