### PR TITLE
fix: drop python 3.13t support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_SKIP: "pp*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_ENABLE: cpython-freethreading
           CIBW_TEST_COMMAND: python {project}/tests/test_cases.py
         with:
           package-dir: ./PythonAPI

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -36,7 +36,7 @@ jobs:
         if: matrix.install_from == 'source'
         shell: bash
         run: |
-          for version in 3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.14t
           do
             uv run --with ./PythonAPI --with '${{ matrix.numpy }}' --python $version --managed-python tests/test_cases.py
           done
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: |
           uv build --sdist ./PythonAPI
-          for version in 3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
+          for version in 3.9 3.10 3.11 3.12 3.13 3.14 3.14t
           do
             uv run --with ./PythonAPI/dist/*.tar.gz --with '${{ matrix.numpy }}' --python $version --managed-python tests/test_cases.py
           done


### PR DESCRIPTION
Removes Python 3.13 free-threading from the unittest matrix and disables the `cpython-freethreading` build option in cibuildwheel.

Since manylinux plans to discontinue support for 3.13t starting May 5, 2026, I am submitting a pull request to discontinue support here as well.

https://github.com/pypa/manylinux/issues/1882

3.14t and above will continue to be built.

> cpython-freethreading: Enable experimental free-threaded builds for CPython 3.13. Free-threading wheels for 3.14+ are available without this flag, as it's [no longer considered experimental](https://peps.python.org/pep-0779/).

